### PR TITLE
Remove deprecated pnpm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npx create astro@latest --template eliancodes/brutal
 npx create astro@latest -- --template eliancodes/brutal
 
 # pnpm
-pnpx create-astro --template eliancodes/brutal
+pnpm dlx create-astro --template eliancodes/brutal
 
 # yarn
 yarn create astro --template eliancodes/brutal


### PR DESCRIPTION
According to the pnpm docs pnpx is considered to be [deprecated](https://pnpm.io/6.x/pnpx-cli). 

> This command is deprecated! Use [pnpm exec](https://pnpm.io/6.x/cli/exec) and [pnpm dlx](https://pnpm.io/6.x/cli/dlx) instead