### PR TITLE
Switching from Google fonts to Bunny fonts

### DIFF
--- a/src/components/layout/BaseHead.astro
+++ b/src/components/layout/BaseHead.astro
@@ -47,10 +47,9 @@ const { title, description, ogImage } = Astro.props;
   <title>Brutal Theme | {title}</title>
 
   <!-- fonts -->
-  <link rel='preconnect' href='https://fonts.googleapis.com' />
-  <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin />
+  <link rel="preconnect" href="https://fonts.bunny.net">
   <link
-    href='https://fonts.googleapis.com/css2?family=DM+Serif+Text&family=Fredoka+One&family=Outfit:wght@400;500&family=Poppins:wght@300;400;500&family=Righteous&family=Sanchez&display=swap'
+    href='https://fonts.bunny.net/css2?family=DM+Serif+Text&family=Fredoka+One&family=Outfit:wght@400;500&family=Poppins:wght@300;400;500&family=Righteous&family=Sanchez&display=swap'
     rel='stylesheet'
   />
 


### PR DESCRIPTION
Google Fonts aren't GDPR compliant - Bunny Fonts (or self-hosting fonts) is recommended:

https://european-alternatives.eu/alternative-to/google-fonts