### PR TITLE
fix: update format for blogpost OG images

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,7 +4,7 @@ import BlogSideBar from '@components/blog/BlogSideBar.astro';
 import BlogContent from '@components/blog/BlogContent.astro';
 import RecentBlogPosts from '@components/generic/RecentBlogPosts.astro';
 
-const ogImage = new URL(`/v1/generate/og/${Astro.params.slug}.svg`, Astro.url);
+const ogImage = new URL(`/v1/generate/og/${Astro.params.slug}.png`, Astro.url);
 
 const { content, headings } = Astro.props;
 const { title, description } = content;


### PR DESCRIPTION
## Changes

- close #50 
- quick fix for the broken OG images to blogpost slugs

<!-- - What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well. -->

## Docs

- not needed
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->