### PR TITLE
chore: update `astro-font` to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@eliancodes/brutal-ui": "^0.2.3",
     "@unocss/astro": "^0.57.7",
     "astro": "^4.5.15",
-    "astro-font": "^0.0.72",
+    "astro-font": "^0.0.80",
     "satori": "^0.5.0",
     "satori-html": "^0.3.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^4.5.15
     version: 4.5.15(typescript@5.3.3)
   astro-font:
-    specifier: ^0.0.72
-    version: 0.0.72
+    specifier: ^0.0.80
+    version: 0.0.80
   satori:
     specifier: ^0.5.0
     version: 0.5.0
@@ -1966,8 +1966,8 @@ packages:
       - supports-color
     dev: true
 
-  /astro-font@0.0.72:
-    resolution: {integrity: sha512-FUjIerovSg2lsfJfvvqY23hgvc++gHi69ikFkxm0mqO3MPFykK5ppeUuROUjhNbE6vwdD8MpiJOy1CR5S0g/lQ==}
+  /astro-font@0.0.80:
+    resolution: {integrity: sha512-RjUANXSNdt0Yp2Tpyn7woBg67hCX2Gy1OiiA7B0NX501LcrzvFHoX98CoBgJC5af3tj3fznfLqqBmMr7wu6+fQ==}
     dev: false
 
   /astro@4.5.15(typescript@5.3.3):


### PR DESCRIPTION
## Changes

Upgrades `astro-font` to the latest

`astro-font` changelog: https://www.launchfa.st/blog/astro-font-changelog

## Docs

Docs are not required as it's a dependency upgrade.