### PR TITLE
Prevent tags going off screen

### DIFF
--- a/src/components/blog/BlogSummaryCard.astro
+++ b/src/components/blog/BlogSummaryCard.astro
@@ -24,7 +24,7 @@ const { post } = Astro.props;
   <div class='hidden sm:inline-block'>
     <p class='poppins mt-2'>tags:</p>
     <div class='flex justify-between items-center'>
-      <ul class='flex gap-4 mt-2'>
+      <ul class='flex flex-wrap gap-4 mt-2'>
         {
           post.data.tags.map((tag) => {
             return (


### PR DESCRIPTION
## Changes

From this:
![image](https://github.com/user-attachments/assets/7dfb7b8a-d5e6-49a9-9ca2-19700ddb1962)

To this:
![image](https://github.com/user-attachments/assets/3faae065-223e-430a-bbe7-e4fd1ad200f1)

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
No docs needed as this is a s small css fix
<!-- Is this a visible change? You probably need to update the README.md -->