### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can bootstrap a new Astro project using Brutal with the following command:
 npx create astro@latest --template eliancodes/brutal
 
 # npm 7+
-npx create astro@latest -- --template eliancodes/brutal
+npm create astro@latest -- --template eliancodes/brutal
 
 # pnpm
 pnpm dlx create-astro --template eliancodes/brutal


### PR DESCRIPTION
changed the command: npx create astro@latest --template eliancodes/brutal To
npm create astro@latest --template eliancodes/brutal Because the npx one is sending back an error but the one with npm working perfectly fine.

## Changes

- Updated the npx command to npm, because when you use npx during cloning its returning an error.

## Docs

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->