### PR TITLE
🐛 Update feed.xml.js - Fix broken post link by replacing slug with id…

### DIFF
--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -12,7 +12,7 @@ export async function GET(context) {
       title: post.data.title,
       pubDate: post.data.pubDate,
       description: post.data.description,
-      link: `/blog/${post.slug}/`,
+      link: `/blog/${post.id}/`,
     })),
     customData: '<language>en-us</language>',
     canonicalUrl: 'https://brutal.elian.codes',


### PR DESCRIPTION
## Changes

From this:

<img width="1596" alt="image" src="https://github.com/user-attachments/assets/d5449e8e-98cc-48ca-95fe-ca479a9e3a0e" />

To this:

<img width="1603" alt="image" src="https://github.com/user-attachments/assets/045a8bf8-f236-455c-9e91-13f326e23507" />

Astro V5 disposes of `post.slug` and replaces with `post.id` in collections. This change allows the RSS reader to be passed the actual post url.

## Docs
[Astro V5](https://docs.astro.build/en/guides/upgrade-to/v5/#updating-existing-collections
)
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->
<!-- Is this a visible change? You probably need to update the README.md -->

No visible change